### PR TITLE
inf: update guid values and versions of modified inf files to avoid conflicts.

### DIFF
--- a/sdm845Pkg/Drivers/LogoDxe/Logo.inf
+++ b/sdm845Pkg/Drivers/LogoDxe/Logo.inf
@@ -17,9 +17,9 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = Logo
   MODULE_UNI_FILE                = Logo.uni
-  FILE_GUID                      = 7BB28B99-61BB-11D5-9A5D-0090273FC14D
+  FILE_GUID                      = 395CD006-FE97-785E-6DEE-4569C3B4411B
   MODULE_TYPE                    = USER_DEFINED
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
 
 #
 # The following information is for reference only and not required by the build tools.

--- a/sdm845Pkg/Drivers/LogoDxe/LogoDxe.inf
+++ b/sdm845Pkg/Drivers/LogoDxe/LogoDxe.inf
@@ -17,9 +17,9 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = LogoDxe
   MODULE_UNI_FILE                = LogoDxe.uni
-  FILE_GUID                      = F74D20EE-37E7-48FC-97F7-9B1047749C69
+  FILE_GUID                      = 53B2C4DB-E840-D17C-76FF-5E49F92383BD
   MODULE_TYPE                    = DXE_DRIVER
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
 
   ENTRY_POINT                    = InitializeLogo
 #

--- a/sdm845Pkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+++ b/sdm845Pkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
@@ -10,9 +10,9 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = ArmMmuBaseLib
-  FILE_GUID                      = da8f0232-fb14-42f0-922c-63104d2c70bd
+  FILE_GUID                      = 459A0113-F77B-4270-7C40-ED473B985ED5
   MODULE_TYPE                    = BASE
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
   LIBRARY_CLASS                  = ArmMmuLib
   CONSTRUCTOR                    = ArmMmuBaseLibConstructor
 

--- a/sdm845Pkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+++ b/sdm845Pkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
@@ -10,9 +10,9 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = ArmMmuPeiLib
-  FILE_GUID                      = b50d8d53-1ad1-44ea-9e69-8c89d4a6d08b
+  FILE_GUID                      = 2FD24913-D00D-6E81-35DE-0EFA5A0AE893
   MODULE_TYPE                    = PEIM
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
   LIBRARY_CLASS                  = ArmMmuLib|PEIM
   CONSTRUCTOR                    = ArmMmuPeiLibConstructor
 

--- a/sdm845Pkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/sdm845Pkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -13,9 +13,9 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = PlatformBootManagerLib
-  FILE_GUID                      = 92FD2DE3-B9CB-4B35-8141-42AD34D73C9F
+  FILE_GUID                      = 6FC7BC89-0B6F-EE12-E6F1-AA6890080905
   MODULE_TYPE                    = DXE_DRIVER
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
   LIBRARY_CLASS                  = PlatformBootManagerLib|DXE_DRIVER
 
 #

--- a/sdm845Pkg/Library/PlatformPeiLib/PlatformPeiLib.inf
+++ b/sdm845Pkg/Library/PlatformPeiLib/PlatformPeiLib.inf
@@ -16,9 +16,9 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = PlatformPeiLib
-  FILE_GUID                      = 59C11815-F8DA-4F49-B4FB-EC1E41ED1F06
+  FILE_GUID                      = F6E440DB-F728-4D8F-B237-88E00FAF4CB5
   MODULE_TYPE                    = SEC
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
   LIBRARY_CLASS                  = PlatformPeiLib
 
 [Sources]

--- a/sdm845Pkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
+++ b/sdm845Pkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.inf
@@ -18,9 +18,9 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = VirtualRealTimeClockLib
-  FILE_GUID                      = 1E27D461-78F3-4F7D-B1C2-F72384F13A6E
+  FILE_GUID                      = 775732DA-086B-4416-8CA9-C284E4585EA7
   MODULE_TYPE                    = BASE
-  VERSION_STRING                 = 1.0
+  VERSION_STRING                 = 1.1
   LIBRARY_CLASS                  = RealTimeClockLib
 
 [Sources.common]


### PR DESCRIPTION
According to the UEFI INF file specification, GUID and version should be modified when cloning a module. In this way, the conflict with the original module can be avoided.