### PR TITLE
remove parallel build param from BaseTools make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ function _build(){
 	source "${_EDK2}/edksetup.sh"
 	[ -d "${WORKSPACE}" ]||mkdir "${WORKSPACE}"
 	set -x
-	make -C "${_EDK2}/BaseTools" -j "$(nproc)"||exit "$?"
+	make -C "${_EDK2}/BaseTools"||exit "$?"
 	if "${GEN_ACPI}" && ! iasl -ve "sdm845Pkg/AcpiTables/${DEVICE}/Dsdt.asl"
 	then echo "iasl failed with ${?}" >&2;return 1
 	fi


### PR DESCRIPTION
tianocore/edk2-platforms recommend not passing any -j option.

Source: https://github.com/tianocore/edk2-platforms/tree/086a3a3ce6c42c859ee5943eb2c4b6edcefdc241#manual-building
(BaseTools can currently not be built in parallel, so do not specify any -j option, either on the command line or in a MAKEFLAGS environment variable.)