### PR TITLE
[.github] Add CI support for fckmtp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
           - trident
           - draco
           - pd1821
+          - fckmtp
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Because why not `¯\_(ツ)_/¯`