### PR TITLE
Restore usb boot support

### DIFF
--- a/sdm845Pkg/Devices/fajita.fdf
+++ b/sdm845Pkg/Devices/fajita.fdf
@@ -506,6 +506,11 @@ APRIORI DXE {
 
   INF sdm845Pkg/Drivers/sdm845Dxe/sdm845Dxe.inf
   INF sdm845Pkg/Drivers/SimpleFbDxe/SimpleFbDxe.inf
+  
+  #
+  # USB Mass Storage Support
+  #
+  INF MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
   #
   # USB Host Support


### PR DESCRIPTION
on current artifact build my fajita-8g cant boot from a usb pen drive , with the proposed changes its able to boot windows 11 arm64 from a 32gb flash drive just fine